### PR TITLE
POLCT-956: Add support for workflow dispatch event in Github

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ try {
 	let githubUsername = process.env.GITHUB_ACTOR
 	let asset_id = process.env.GITHUB_REPOSITORY
 
-	if( process.env.GITHUB_EVENT_NAME === "push" ){
+	if( process.env.GITHUB_EVENT_NAME === "push" || process.env.GITHUB_EVENT_NAME === "workflow_dispatch"){
 		scmBranchName = process.env.GITHUB_REF.split('/')[2]
 	}
 	else if( process.env.GITHUB_EVENT_NAME === "pull_request") {


### PR DESCRIPTION
Currently , we support push and pull_request event for the github integrations. There is one more event "workflow_dispatch" event to trigger the workflow manually. QA will be using this event for our automation.
so have added support for workflow dispatch event.